### PR TITLE
21я домашка

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ venv
 __pycache__
 credentials.py
 .env
+requirements.txt
+allure-results
+allure-report

--- a/test_api_lyadov/conftest.py
+++ b/test_api_lyadov/conftest.py
@@ -1,10 +1,10 @@
 import pytest
 import requests
 from endpoints.create_post import CreatePost
-from endpoints.create_get import CreateGet
 from endpoints.update_put import UpdatePut
 from endpoints.update_patch import UpdatePatch
 from endpoints.update_delete import UpdateDelete
+from endpoints.update_get import UpdateGet
 
 
 @pytest.fixture()
@@ -14,7 +14,7 @@ def create_new_obj():
 
 @pytest.fixture()
 def get_all_obj():
-    return CreateGet()
+    return UpdateGet()
 
 
 @pytest.fixture()
@@ -25,10 +25,13 @@ def new_obj():
                 "size": "test_homework18_size444444444"
             }
             }
-    response = requests.post(
-        'http://167.172.172.115:52353/object', json=body).json()
-    print(response)
-    return response['id']
+    response = CreatePost().generate_new_objects(body)
+    response_data = response.json()
+    obj_id = response_data['id']
+    print(f"Created object with ID: {obj_id}")
+    yield response_data['id']
+    print(f"Deleting object with ID: {obj_id}")
+    UpdateDelete().update_obj_delete(obj_id)
 
 
 @pytest.fixture()

--- a/test_api_lyadov/conftest.py
+++ b/test_api_lyadov/conftest.py
@@ -44,4 +44,3 @@ def patch_obj():
 @pytest.fixture()
 def delete_obj():
     return UpdateDelete()
-

--- a/test_api_lyadov/conftest.py
+++ b/test_api_lyadov/conftest.py
@@ -1,0 +1,47 @@
+import pytest
+import requests
+from endpoints.create_post import CreatePost
+from endpoints.create_get import CreateGet
+from endpoints.update_put import UpdatePut
+from endpoints.update_patch import UpdatePatch
+from endpoints.update_delete import UpdateDelete
+
+
+@pytest.fixture()
+def create_new_obj():
+    return CreatePost()
+
+
+@pytest.fixture()
+def get_all_obj():
+    return CreateGet()
+
+
+@pytest.fixture()
+def new_obj():
+    body = {"name": "homework18_test222222222",
+            "data": {
+                "color": "test_homework18_color33333333333",
+                "size": "test_homework18_size444444444"
+            }
+            }
+    response = requests.post(
+        'http://167.172.172.115:52353/object', json=body).json()
+    print(response)
+    return response['id']
+
+
+@pytest.fixture()
+def put_obj():
+    return UpdatePut()
+
+
+@pytest.fixture()
+def patch_obj():
+    return UpdatePatch()
+
+
+@pytest.fixture()
+def delete_obj():
+    return UpdateDelete()
+

--- a/test_api_lyadov/endpoints/create_get.py
+++ b/test_api_lyadov/endpoints/create_get.py
@@ -1,0 +1,46 @@
+import requests
+import allure
+from endpoints.endpoint import Endpoint
+
+
+class CreateGet(Endpoint):
+
+    @allure.step('Вызов get запроса со всеми объектами')
+    def challenge_all_obj(self):
+        self.response = requests.get(self.url)
+        self.json = self.response.json()
+        return self.response
+
+    @allure.step('Проверяем, что ответ содержит поле "data" и это список')
+    def check_data_response(self):
+        assert 'data' in self.json, \
+            "Response doesn't contain 'data' field"
+        assert isinstance(self.json['data'], list), \
+            "'data' is not a list"
+
+    @allure.step('Для каждого объекта в data '
+                 'проверяем наличие обязательных полей')
+    def check_objs_response(self):
+        for obj in self.json['data']:
+            assert 'id' in obj, \
+                f"Object missing 'id' field: {obj}"
+            assert 'name' in obj, \
+                f"Object missing 'name' field: {obj}"
+            assert 'data' in obj, \
+                f"Object missing 'data' field: {obj}"
+
+    @allure.step('Вызов get запроса и передача в него фикстуры с id')
+    def challenge_one_obj(self, new_obj):
+        self.response = requests.get(f'{self.url}/{new_obj}')
+        self.json = self.response.json()
+        return self.response
+
+    @allure.step('Проверяем, что "id" есть в ответе')
+    def checkget_id_in_response(self):
+        assert "id" in self.json, \
+            f"Response missing 'id' field: {self.json}"
+
+    @allure.step('Сравниваем id в запросе с id в new_obj')
+    def check_id_in_new_obj(self, new_obj):
+        assert self.json['id'] == new_obj, \
+            f"Expected id={new_obj}, but got {self.json['id']}"

--- a/test_api_lyadov/endpoints/create_post.py
+++ b/test_api_lyadov/endpoints/create_post.py
@@ -27,7 +27,7 @@ class CreatePost(Endpoint):
 
     @allure.step('Вызов post запроса с передачей '
                  'в него параметров из переменной body')
-    def create_new_post(self, body):
+    def generate_new_objects(self, body):
         self.response = requests.post(self.url, json=body)
         self.json = self.response.json()
         return self.response

--- a/test_api_lyadov/endpoints/create_post.py
+++ b/test_api_lyadov/endpoints/create_post.py
@@ -1,0 +1,43 @@
+import requests
+import allure
+from endpoints.endpoint import Endpoint
+
+
+class CreatePost(Endpoint):
+    TEST_DATA = [
+        ("homework18_test11",
+         "test_homework18_color11", "test_homework18_size11"),
+        ("homework18_test22",
+         "test_homework18_color22", "test_homework18_size22"),
+        ("homework18_test33",
+         "test_homework18_color33", "test_homework18_size33")
+    ]
+
+    @allure.step('Создаем переменную body '
+                 'и передаем в нее параметры из parametrize')
+    def create_body(self, name, color, size):
+        body = {
+            "name": name,
+            "data": {
+                "color": color,
+                "size": size
+            }
+        }
+        return body
+
+    @allure.step('Вызов post запроса с передачей '
+                 'в него параметров из переменной body')
+    def create_new_post(self, body):
+        self.response = requests.post(self.url, json=body)
+        self.json = self.response.json()
+        return self.response
+
+    @allure.step('Проверяем, что "id" есть в ответе')
+    def check_id_in_response(self):
+        assert "id" in self.json
+
+    @allure.step('Сравнивает ответ с ожидаемыми значениями')
+    def check_body_and_response(self, name, color, size):
+        assert self.json["name"] == name
+        assert self.json["data"]["color"] == color
+        assert self.json["data"]["size"] == size

--- a/test_api_lyadov/endpoints/endpoint.py
+++ b/test_api_lyadov/endpoints/endpoint.py
@@ -1,0 +1,22 @@
+import allure
+
+
+class Endpoint:
+    url = 'http://167.172.172.115:52353/object'
+    response = None
+    json = None
+
+    @allure.step('Check that response is 200')
+    def check_status_is_200(self):
+        assert self.response.status_code == 200
+
+    @allure.step('Проверка объектов в ответе и в body')
+    def check_objs_in_body(self, body):
+        assert self.json['name'] == body['name'], \
+            f"Expected name {body['name']}, but got {self.json['name']}"
+        assert self.json['data']['color'] == body['data']['color'], \
+            (f"Expected color {body['data']['color']}, "
+             f"but got {self.json['data']['color']}")
+        assert self.json['data']['size'] == body['data']['size'], \
+            (f"Expected size {body['data']['size']}, "
+             f"but got {self.json['data']['size']}")

--- a/test_api_lyadov/endpoints/update_delete.py
+++ b/test_api_lyadov/endpoints/update_delete.py
@@ -1,0 +1,12 @@
+import requests
+import allure
+from endpoints.endpoint import Endpoint
+
+
+class UpdateDelete(Endpoint):
+
+    @allure.step('Обновление delete запросом')
+    def update_obj_delete(self, new_obj):
+        self.response = requests.delete(f'{self.url}/{new_obj}')
+        # self.json = self.response.json()
+        return self.response

--- a/test_api_lyadov/endpoints/update_get.py
+++ b/test_api_lyadov/endpoints/update_get.py
@@ -3,7 +3,7 @@ import allure
 from endpoints.endpoint import Endpoint
 
 
-class CreateGet(Endpoint):
+class UpdateGet(Endpoint):
 
     @allure.step('Вызов get запроса со всеми объектами')
     def challenge_all_obj(self):

--- a/test_api_lyadov/endpoints/update_patch.py
+++ b/test_api_lyadov/endpoints/update_patch.py
@@ -1,0 +1,22 @@
+import requests
+import allure
+from endpoints.endpoint import Endpoint
+
+
+class UpdatePatch(Endpoint):
+
+    @allure.step('Создаем переменную body')
+    def create_body_patch(self):
+        body = {"name": "homework1812313",
+                "data": {
+                    "color": "113131homework18_color2",
+                    "size": "1313133homework18_size2"
+                }
+                }
+        return body
+
+    @allure.step('Обновление patch запросом')
+    def update_obj_patch(self, new_obj, body):
+        self.response = requests.patch(f'{self.url}/{new_obj}', json=body)
+        self.json = self.response.json()
+        return self.response

--- a/test_api_lyadov/endpoints/update_put.py
+++ b/test_api_lyadov/endpoints/update_put.py
@@ -1,0 +1,22 @@
+import requests
+import allure
+from endpoints.endpoint import Endpoint
+
+
+class UpdatePut(Endpoint):
+
+    @allure.step('Создаем переменную body')
+    def create_body_put(self):
+        body = {"name": "homework1812313",
+                "data": {
+                    "color": "113131homework18_color2",
+                    "size": "1313133homework18_size2"
+                }
+                }
+        return body
+
+    @allure.step('Обновление put запросом')
+    def update_obj_put(self, new_obj, body):
+        self.response = requests.put(f'{self.url}/{new_obj}', json=body)
+        self.json = self.response.json()
+        return self.response

--- a/test_api_lyadov/pytest.ini
+++ b/test_api_lyadov/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    critical
+    medium

--- a/test_api_lyadov/tests/test_methods.py
+++ b/test_api_lyadov/tests/test_methods.py
@@ -9,7 +9,7 @@ from endpoints.create_post import CreatePost
 @pytest.mark.critical
 @pytest.mark.parametrize("name, color, size", CreatePost().TEST_DATA)
 def test_new_obj(name, color, size, create_new_obj):
-    create_new_obj.create_new_post(
+    create_new_obj.generate_new_objects(
         create_new_obj.create_body(name, color, size))
     create_new_obj.check_status_is_200()
     create_new_obj.check_id_in_response()

--- a/test_api_lyadov/tests/test_methods.py
+++ b/test_api_lyadov/tests/test_methods.py
@@ -1,0 +1,65 @@
+import pytest
+import allure
+from endpoints.create_post import CreatePost
+
+
+@allure.feature('Manipulate post')
+@allure.story('Post')
+@allure.title('Создание 3 новых объекта')
+@pytest.mark.critical
+@pytest.mark.parametrize("name, color, size", CreatePost().TEST_DATA)
+def test_new_obj(name, color, size, create_new_obj):
+    create_new_obj.create_new_post(
+        create_new_obj.create_body(name, color, size))
+    create_new_obj.check_status_is_200()
+    create_new_obj.check_id_in_response()
+    create_new_obj.check_body_and_response(name, color, size)
+
+
+@allure.feature('Get post')
+@allure.story('Get')
+@allure.title('Получение всех объектов')
+def test_all_obj(get_all_obj):
+    get_all_obj.challenge_all_obj()
+    get_all_obj.check_status_is_200()
+    get_all_obj.check_data_response()
+    get_all_obj.check_objs_response()
+
+
+@allure.feature('Get post')
+@allure.story('Get')
+@allure.title('Получение одного объекта')
+def test_one_obj(get_all_obj, new_obj):
+    get_all_obj.challenge_one_obj(new_obj)
+    get_all_obj.check_status_is_200()
+    get_all_obj.checkget_id_in_response()
+    get_all_obj.check_id_in_new_obj(new_obj)
+
+
+@allure.feature('Manipulate post')
+@allure.story('Put')
+@allure.title('Обновление put запросом')
+@pytest.mark.medium
+def test_put_obj(put_obj, new_obj):
+    body = put_obj.create_body_put()
+    put_obj.update_obj_put(new_obj, body)
+    put_obj.check_status_is_200()
+    put_obj.check_objs_in_body(body)
+
+
+@allure.feature('Manipulate post')
+@allure.story('Patch')
+@allure.title('Обновление patch запросом')
+def test_patch_obj(patch_obj, new_obj):
+    body = patch_obj.create_body_patch()
+    patch_obj.update_obj_patch(new_obj, body)
+    patch_obj.check_status_is_200()
+    patch_obj.check_objs_in_body(body)
+
+
+@allure.feature('Manipulate post')
+@allure.story('Delete')
+@allure.title('Удаление объекта')
+def test_delete_obj(delete_obj, new_obj):
+    delete_obj.update_obj_delete(new_obj)
+    delete_obj.check_status_is_200()


### PR DESCRIPTION
@eugene-okulik Привет! 21я домашка. По поводу переносов декораторов pytest и allure, я не стал их переносить т.к. они должны находиться в тестах, вот что на это пишут
@pytest.mark.parametrize
Этот декоратор работает только с тестовыми функциями (функциями, которые начинаются с test_ или используют pytest-фикстуры). Он не может быть применён к методам класса, если они не являются тестами.

@allure.title/@allure.feature
Allure-декораторы для фич/стори/степов применимы к:

Тестовым функциям.

Методам класса, если это тест-класс (унаследованный от unittest.TestCase или с декоратором @pytest.mark.usefixtures).
Мои классы это обычные классы с логикой, а не тест-кейсы.

@pytest.mark.critical
Метки pytest тоже работают только для тестов, а не для вспомогательных классов.
Там конечно можно выкрутиться и создать тестовые классы и с ними уже работать, но я так понимаю нам здесь это не нужно.